### PR TITLE
Remove byteorder dependency because it depends on std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cc"
 version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,7 +245,6 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 name = "simple-someip"
 version = "0.2.0"
 dependencies = [
- "byteorder",
  "chrono",
  "crc",
  "socket2 0.5.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byteorder = "1"
 crc = "3"
 chrono = { version = "0.4", features = ["serde"] }
 socket2 = "0.5"

--- a/src/protocol/byte_order.rs
+++ b/src/protocol/byte_order.rs
@@ -1,0 +1,77 @@
+use crate::protocol::Error;
+
+/// Extension trait for reading big-endian integers from a byte stream.
+///
+/// This trait is intentionally decoupled from `std::io::Read` so it can
+/// later be backed by `embedded_io::Read` without changing call sites.
+/// The only required method is [`read_bytes`](ReadBytesExt::read_bytes),
+/// which is adapted to `std::io::Read` via a blanket impl.
+pub(crate) trait ReadBytesExt {
+    /// Read exactly `buf.len()` bytes into `buf`.
+    fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error>;
+
+    fn read_u8(&mut self) -> Result<u8, Error> {
+        let mut buf = [0u8; 1];
+        self.read_bytes(&mut buf)?;
+        Ok(buf[0])
+    }
+
+    fn read_u16_be(&mut self) -> Result<u16, Error> {
+        let mut buf = [0u8; 2];
+        self.read_bytes(&mut buf)?;
+        Ok(u16::from_be_bytes(buf))
+    }
+
+    fn read_u24_be(&mut self) -> Result<u32, Error> {
+        let mut buf = [0u8; 3];
+        self.read_bytes(&mut buf)?;
+        Ok(u32::from_be_bytes([0, buf[0], buf[1], buf[2]]))
+    }
+
+    fn read_u32_be(&mut self) -> Result<u32, Error> {
+        let mut buf = [0u8; 4];
+        self.read_bytes(&mut buf)?;
+        Ok(u32::from_be_bytes(buf))
+    }
+}
+
+impl<T: std::io::Read> ReadBytesExt for T {
+    fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+        self.read_exact(buf)?;
+        Ok(())
+    }
+}
+
+/// Extension trait for writing big-endian integers to a byte stream.
+///
+/// This trait is intentionally decoupled from `std::io::Write` so it can
+/// later be backed by `embedded_io::Write` without changing call sites.
+/// The only required method is [`write_bytes`](WriteBytesExt::write_bytes),
+/// which is adapted to `std::io::Write` via a blanket impl.
+pub(crate) trait WriteBytesExt {
+    /// Write all bytes from `buf` to the stream.
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Error>;
+
+    fn write_u8(&mut self, val: u8) -> Result<(), Error> {
+        self.write_bytes(&[val])
+    }
+
+    fn write_u16_be(&mut self, val: u16) -> Result<(), Error> {
+        self.write_bytes(&val.to_be_bytes())
+    }
+
+    fn write_u24_be(&mut self, val: u32) -> Result<(), Error> {
+        self.write_bytes(&val.to_be_bytes()[1..])
+    }
+
+    fn write_u32_be(&mut self, val: u32) -> Result<(), Error> {
+        self.write_bytes(&val.to_be_bytes())
+    }
+}
+
+impl<T: std::io::Write> WriteBytesExt for T {
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Error> {
+        self.write_all(buf)?;
+        Ok(())
+    }
+}

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -1,7 +1,8 @@
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-
 use crate::{
-    protocol::{Error, MessageId, MessageTypeField, ReturnCode},
+    protocol::{
+        Error, MessageId, MessageTypeField, ReturnCode,
+        byte_order::{ReadBytesExt, WriteBytesExt},
+    },
     traits::WireFormat,
 };
 
@@ -51,9 +52,9 @@ impl Header {
 
 impl WireFormat for Header {
     fn decode<T: std::io::Read>(reader: &mut T) -> Result<Self, Error> {
-        let message_id = MessageId::from(reader.read_u32::<BigEndian>()?);
-        let length = reader.read_u32::<BigEndian>()?;
-        let request_id = reader.read_u32::<BigEndian>()?;
+        let message_id = MessageId::from(reader.read_u32_be()?);
+        let length = reader.read_u32_be()?;
+        let request_id = reader.read_u32_be()?;
         let protocol_version = reader.read_u8()?;
         if protocol_version != 0x01 {
             return Err(Error::InvalidProtocolVersion(protocol_version));
@@ -77,9 +78,9 @@ impl WireFormat for Header {
     }
 
     fn encode<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, Error> {
-        writer.write_u32::<BigEndian>(self.message_id.message_id())?;
-        writer.write_u32::<BigEndian>(self.length)?;
-        writer.write_u32::<BigEndian>(self.session_id)?;
+        writer.write_u32_be(self.message_id.message_id())?;
+        writer.write_u32_be(self.length)?;
+        writer.write_u32_be(self.session_id)?;
         writer.write_u8(self.protocol_version)?;
         writer.write_u8(self.interface_version)?;
         writer.write_u8(u8::from(self.message_type))?;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod byte_order;
 mod error;
 mod header;
 mod message;

--- a/src/protocol/sd/entry.rs
+++ b/src/protocol/sd/entry.rs
@@ -1,7 +1,10 @@
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{Read, Write};
-
-use crate::{protocol::Error, traits::WireFormat};
+use crate::{
+    protocol::{
+        Error,
+        byte_order::{ReadBytesExt, WriteBytesExt},
+    },
+    traits::WireFormat,
+};
 
 pub const ENTRY_SIZE: usize = 16;
 
@@ -119,12 +122,12 @@ impl WireFormat for EventGroupEntry {
         let index_first_options_run = reader.read_u8()?;
         let index_second_options_run = reader.read_u8()?;
         let options_count = OptionsCount::from(reader.read_u8()?);
-        let service_id = reader.read_u16::<BigEndian>()?;
-        let instance_id = reader.read_u16::<BigEndian>()?;
+        let service_id = reader.read_u16_be()?;
+        let instance_id = reader.read_u16_be()?;
         let major_version = reader.read_u8()?;
-        let ttl = reader.read_u24::<BigEndian>()?;
-        let counter = reader.read_u16::<BigEndian>()? & 0x000f;
-        let event_group_id = reader.read_u16::<BigEndian>()?;
+        let ttl = reader.read_u24_be()?;
+        let counter = reader.read_u16_be()? & 0x000f;
+        let event_group_id = reader.read_u16_be()?;
         Ok(Self {
             index_first_options_run,
             index_second_options_run,
@@ -149,12 +152,12 @@ impl WireFormat for EventGroupEntry {
         writer.write_u8(self.index_first_options_run)?;
         writer.write_u8(self.index_second_options_run)?;
         writer.write_u8(u8::from(self.options_count))?;
-        writer.write_u16::<BigEndian>(self.service_id)?;
-        writer.write_u16::<BigEndian>(self.instance_id)?;
+        writer.write_u16_be(self.service_id)?;
+        writer.write_u16_be(self.instance_id)?;
         writer.write_u8(self.major_version)?;
-        writer.write_u24::<BigEndian>(self.ttl)?;
-        writer.write_u16::<BigEndian>(self.counter)?;
-        writer.write_u16::<BigEndian>(self.event_group_id)?;
+        writer.write_u24_be(self.ttl)?;
+        writer.write_u16_be(self.counter)?;
+        writer.write_u16_be(self.event_group_id)?;
         Ok(16)
     }
 }
@@ -189,15 +192,15 @@ impl ServiceEntry {
 }
 
 impl WireFormat for ServiceEntry {
-    fn decode<R: Read>(reader: &mut R) -> Result<Self, Error> {
+    fn decode<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
         let index_first_options_run = reader.read_u8()?;
         let index_second_options_run = reader.read_u8()?;
         let options_count = OptionsCount::from(reader.read_u8()?);
-        let service_id = reader.read_u16::<BigEndian>()?;
-        let instance_id = reader.read_u16::<BigEndian>()?;
+        let service_id = reader.read_u16_be()?;
+        let instance_id = reader.read_u16_be()?;
         let major_version = reader.read_u8()?;
-        let ttl = reader.read_u24::<BigEndian>()?;
-        let minor_version = reader.read_u32::<BigEndian>()?;
+        let ttl = reader.read_u24_be()?;
+        let minor_version = reader.read_u32_be()?;
         Ok(Self {
             index_first_options_run,
             index_second_options_run,
@@ -214,15 +217,15 @@ impl WireFormat for ServiceEntry {
         16
     }
 
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         writer.write_u8(self.index_first_options_run)?;
         writer.write_u8(self.index_second_options_run)?;
         writer.write_u8(u8::from(self.options_count))?;
-        writer.write_u16::<BigEndian>(self.service_id)?;
-        writer.write_u16::<BigEndian>(self.instance_id)?;
+        writer.write_u16_be(self.service_id)?;
+        writer.write_u16_be(self.instance_id)?;
         writer.write_u8(self.major_version)?;
-        writer.write_u24::<BigEndian>(self.ttl)?;
-        writer.write_u32::<BigEndian>(self.minor_version)?;
+        writer.write_u24_be(self.ttl)?;
+        writer.write_u32_be(self.minor_version)?;
         Ok(16)
     }
 }
@@ -274,7 +277,7 @@ impl Entry {
 }
 
 impl WireFormat for Entry {
-    fn decode<R: Read>(reader: &mut R) -> Result<Self, Error> {
+    fn decode<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
         let entry_type = EntryType::try_from(reader.read_u8()?)?;
         match entry_type {
             EntryType::FindService => {
@@ -312,7 +315,7 @@ impl WireFormat for Entry {
         }
     }
 
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         match self {
             Entry::FindService(service_entry) => {
                 writer.write_u8(u8::from(EntryType::FindService))?;

--- a/src/protocol/sd/header.rs
+++ b/src/protocol/sd/header.rs
@@ -1,5 +1,6 @@
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::{net::Ipv4Addr, vec};
+
+use crate::protocol::byte_order::{ReadBytesExt, WriteBytesExt};
 
 use crate::{protocol::Error, traits::WireFormat};
 
@@ -130,8 +131,8 @@ impl WireFormat for Header {
     fn decode<T: std::io::Read>(reader: &mut T) -> Result<Self, crate::protocol::Error> {
         let flags = Flags::from(reader.read_u8()?);
         let mut reserved: [u8; 3] = [0; 3];
-        reader.read_exact(&mut reserved)?;
-        let entries_size = reader.read_u32::<BigEndian>()?;
+        reader.read_bytes(&mut reserved)?;
+        let entries_size = reader.read_u32_be()?;
         let entries_count = entries_size / u32::try_from(ENTRY_SIZE).expect("constant fits u32");
         let mut entries = Vec::with_capacity(entries_count as usize);
         let options_count: usize = 0;
@@ -139,7 +140,7 @@ impl WireFormat for Header {
             entries.push(Entry::decode(reader)?);
         }
 
-        let mut remaining_options_size = reader.read_u32::<BigEndian>()? as usize;
+        let mut remaining_options_size = reader.read_u32_be()? as usize;
         let mut options = Vec::with_capacity(options_count);
         while remaining_options_size > 0 {
             options.push(Options::read(reader)?);
@@ -169,9 +170,9 @@ impl WireFormat for Header {
     ) -> Result<usize, crate::protocol::Error> {
         writer.write_u8(u8::from(self.flags))?;
         let reserved: [u8; 3] = [0; 3];
-        writer.write_all(&reserved)?;
+        writer.write_bytes(&reserved)?;
         let entries_size = u32::try_from(self.entries.len() * 16).expect("entries size fits u32");
-        writer.write_u32::<BigEndian>(entries_size)?;
+        writer.write_u32_be(entries_size)?;
         for entry in &self.entries {
             entry.encode(writer)?;
         }
@@ -179,7 +180,7 @@ impl WireFormat for Header {
         for option in &self.options {
             options_size += option.size();
         }
-        writer.write_u32::<BigEndian>(u32::try_from(options_size).expect("options size fits u32"))?;
+        writer.write_u32_be(u32::try_from(options_size).expect("options size fits u32"))?;
         for option in &self.options {
             option.write(writer)?;
         }

--- a/src/protocol/sd/options.rs
+++ b/src/protocol/sd/options.rs
@@ -1,11 +1,9 @@
-use std::{
-    io::{Read, Write},
-    net::Ipv4Addr,
+use std::net::Ipv4Addr;
+
+use crate::protocol::{
+    Error,
+    byte_order::{ReadBytesExt, WriteBytesExt},
 };
-
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-
-use crate::protocol::Error;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum TransportProtocol {
@@ -107,18 +105,18 @@ impl Options {
         }
     }
 
-    pub fn write<T: Write>(&self, writer: &mut T) -> Result<usize, Error> {
-        writer.write_u16::<BigEndian>(u16::try_from(self.size() - 3).expect("option size fits u16"))?;
+    pub fn write<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, Error> {
+        writer.write_u16_be(u16::try_from(self.size() - 3).expect("option size fits u16"))?;
         match self {
             Options::Configuration => todo!("Options::Configuration not implemented"),
             Options::LoadBalancing => todo!("Options::Configuration not implemented"),
             Options::IpV4Endpoint { ip, protocol, port } => {
                 writer.write_u8(u8::from(OptionType::IpV4Endpoint))?;
                 writer.write_u8(0)?;
-                writer.write_u32::<BigEndian>(ip.to_bits())?;
+                writer.write_u32_be(ip.to_bits())?;
                 writer.write_u8(0)?;
                 writer.write_u8(u8::from(*protocol))?;
-                writer.write_u16::<BigEndian>(*port)?;
+                writer.write_u16_be(*port)?;
                 Ok(12)
             }
             Options::IpV6Endpoint => todo!("Options::Configuration not implemented"),
@@ -129,8 +127,8 @@ impl Options {
         }
     }
 
-    pub fn read<T: Read>(message_bytes: &mut T) -> Result<Self, Error> {
-        let length = message_bytes.read_u16::<BigEndian>()?;
+    pub fn read<T: std::io::Read>(message_bytes: &mut T) -> Result<Self, Error> {
+        let length = message_bytes.read_u16_be()?;
         let option_type = OptionType::try_from(message_bytes.read_u8()?)?;
         let discard_flag = message_bytes.read_u8()? & 0x80 != 0;
 
@@ -144,11 +142,11 @@ impl Options {
             OptionType::IpV4Endpoint => {
                 assert!(length == 9, "Invalid length for IpV4Endpoint");
                 assert!(!discard_flag, "Discard flag not set");
-                let ip = Ipv4Addr::from_bits(message_bytes.read_u32::<BigEndian>()?);
+                let ip = Ipv4Addr::from_bits(message_bytes.read_u32_be()?);
                 let reserved = message_bytes.read_u8()?;
                 assert!(reserved == 0, "Reserved byte not zero");
                 let protocol = TransportProtocol::try_from(message_bytes.read_u8()?)?;
-                let port = message_bytes.read_u16::<BigEndian>()?;
+                let port = message_bytes.read_u16_be()?;
                 Ok(Options::IpV4Endpoint { ip, protocol, port })
             }
             OptionType::IpV6Endpoint => {


### PR DESCRIPTION
There is still a bit of cleanup to come with std still being required for a few more PRs