### PR TITLE
switch to embedded io traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +253,7 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "crc",
+ "embedded-io",
  "socket2 0.5.10",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 crc = "3"
+embedded-io = { version = "0.7", features = ["std"] }
 chrono = { version = "0.4", features = ["serde"] }
 socket2 = "0.5"
 thiserror = "2"

--- a/src/protocol/byte_order.rs
+++ b/src/protocol/byte_order.rs
@@ -1,11 +1,10 @@
 use crate::protocol::Error;
+use embedded_io::Error as _;  // for .kind() method
 
 /// Extension trait for reading big-endian integers from a byte stream.
 ///
-/// This trait is intentionally decoupled from `std::io::Read` so it can
-/// later be backed by `embedded_io::Read` without changing call sites.
-/// The only required method is [`read_bytes`](ReadBytesExt::read_bytes),
-/// which is adapted to `std::io::Read` via a blanket impl.
+/// The only required method is [`read_bytes`](ReadBytesExt::read_bytes).
+/// Backed by `embedded_io::Read` via a blanket impl.
 pub(crate) trait ReadBytesExt {
     /// Read exactly `buf.len()` bytes into `buf`.
     fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error>;
@@ -35,19 +34,23 @@ pub(crate) trait ReadBytesExt {
     }
 }
 
-impl<T: std::io::Read> ReadBytesExt for T {
+impl<T: embedded_io::Read> ReadBytesExt for T {
     fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
-        self.read_exact(buf)?;
-        Ok(())
+        self.read_exact(buf).map_err(|e| match e {
+            embedded_io::ReadExactError::UnexpectedEof => {
+                Error::Io(std::io::ErrorKind::UnexpectedEof.into())
+            }
+            embedded_io::ReadExactError::Other(e) => {
+                Error::Io(std::io::Error::other(format!("{:?}", e.kind())))
+            }
+        })
     }
 }
 
 /// Extension trait for writing big-endian integers to a byte stream.
 ///
-/// This trait is intentionally decoupled from `std::io::Write` so it can
-/// later be backed by `embedded_io::Write` without changing call sites.
-/// The only required method is [`write_bytes`](WriteBytesExt::write_bytes),
-/// which is adapted to `std::io::Write` via a blanket impl.
+/// The only required method is [`write_bytes`](WriteBytesExt::write_bytes).
+/// Backed by `embedded_io::Write` via a blanket impl.
 pub(crate) trait WriteBytesExt {
     /// Write all bytes from `buf` to the stream.
     fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Error>;
@@ -69,9 +72,42 @@ pub(crate) trait WriteBytesExt {
     }
 }
 
-impl<T: std::io::Write> WriteBytesExt for T {
+impl<T: embedded_io::Write> WriteBytesExt for T {
     fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Error> {
-        self.write_all(buf)?;
-        Ok(())
+        self.write_all(buf).map_err(|e| {
+            Error::Io(std::io::Error::other(format!("{:?}", e.kind())))
+        })
+    }
+}
+
+/// A reader wrapper that limits reads to a specified number of bytes.
+/// Equivalent to `std::io::Read::take()` but works with `embedded_io::Read`.
+pub(crate) struct Take<'a, R> {
+    inner: &'a mut R,
+    remaining: usize,
+}
+
+impl<'a, R> Take<'a, R> {
+    pub fn new(inner: &'a mut R, limit: usize) -> Self {
+        Self {
+            inner,
+            remaining: limit,
+        }
+    }
+}
+
+impl<R: embedded_io::ErrorType> embedded_io::ErrorType for Take<'_, R> {
+    type Error = R::Error;
+}
+
+impl<R: embedded_io::Read> embedded_io::Read for Take<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if self.remaining == 0 {
+            return Ok(0);
+        }
+        let max = buf.len().min(self.remaining);
+        let n = self.inner.read(&mut buf[..max])?;
+        self.remaining -= n;
+        Ok(n)
     }
 }

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -51,7 +51,7 @@ impl Header {
 }
 
 impl WireFormat for Header {
-    fn decode<T: std::io::Read>(reader: &mut T) -> Result<Self, Error> {
+    fn decode<T: embedded_io::Read>(reader: &mut T) -> Result<Self, Error> {
         let message_id = MessageId::from(reader.read_u32_be()?);
         let length = reader.read_u32_be()?;
         let request_id = reader.read_u32_be()?;
@@ -77,7 +77,7 @@ impl WireFormat for Header {
         16
     }
 
-    fn encode<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, Error> {
+    fn encode<T: embedded_io::Write>(&self, writer: &mut T) -> Result<usize, Error> {
         writer.write_u32_be(self.message_id.message_id())?;
         writer.write_u32_be(self.length)?;
         writer.write_u32_be(self.session_id)?;

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -1,7 +1,5 @@
-use std::io::{Read, Write};
-
 use crate::{
-    protocol::{Error, Header, MessageType, ReturnCode, sd},
+    protocol::{Error, Header, MessageType, ReturnCode, byte_order::Take, sd},
     traits::{PayloadWireFormat, WireFormat},
 };
 
@@ -16,7 +14,7 @@ impl<PayloadDefinition: PayloadWireFormat> Message<PayloadDefinition> {
         Self { header, payload }
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn new_sd(session_id: u32, sd_header: &sd::Header) -> Self {
         let sd_header_size = sd_header.required_size();
         Self::new(
@@ -53,7 +51,7 @@ impl<PayloadDefinition: PayloadWireFormat> Message<PayloadDefinition> {
 }
 
 impl<PayloadDefinition: PayloadWireFormat> WireFormat for Message<PayloadDefinition> {
-    fn decode<R: Read>(reader: &mut R) -> Result<Self, Error> {
+    fn decode<R: embedded_io::Read>(reader: &mut R) -> Result<Self, Error> {
         let header = Header::decode(reader)?;
         if header.message_id.is_sd() {
             assert!(header.payload_size() >= 12, "SD message too short");
@@ -74,7 +72,7 @@ impl<PayloadDefinition: PayloadWireFormat> WireFormat for Message<PayloadDefinit
                 "SD return code mismatch"
             );
         }
-        let mut payload_reader = reader.take(header.payload_size() as u64);
+        let mut payload_reader = Take::new(reader, header.payload_size());
         let payload =
             PayloadDefinition::decode_with_message_id(header.message_id, &mut payload_reader)?;
         Ok(Self::new(header, payload))
@@ -84,7 +82,7 @@ impl<PayloadDefinition: PayloadWireFormat> WireFormat for Message<PayloadDefinit
         self.header.required_size() + self.payload.required_size()
     }
 
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn encode<W: embedded_io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         Ok(self.header.encode(writer)? + self.payload.encode(writer)?)
     }
 }

--- a/src/protocol/sd/entry.rs
+++ b/src/protocol/sd/entry.rs
@@ -118,7 +118,7 @@ impl EventGroupEntry {
 }
 
 impl WireFormat for EventGroupEntry {
-    fn decode<T: std::io::Read>(reader: &mut T) -> Result<Self, crate::protocol::Error> {
+    fn decode<T: embedded_io::Read>(reader: &mut T) -> Result<Self, crate::protocol::Error> {
         let index_first_options_run = reader.read_u8()?;
         let index_second_options_run = reader.read_u8()?;
         let options_count = OptionsCount::from(reader.read_u8()?);
@@ -145,7 +145,7 @@ impl WireFormat for EventGroupEntry {
         16
     }
 
-    fn encode<T: std::io::Write>(
+    fn encode<T: embedded_io::Write>(
         &self,
         writer: &mut T,
     ) -> Result<usize, crate::protocol::Error> {
@@ -192,7 +192,7 @@ impl ServiceEntry {
 }
 
 impl WireFormat for ServiceEntry {
-    fn decode<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
+    fn decode<R: embedded_io::Read>(reader: &mut R) -> Result<Self, Error> {
         let index_first_options_run = reader.read_u8()?;
         let index_second_options_run = reader.read_u8()?;
         let options_count = OptionsCount::from(reader.read_u8()?);
@@ -217,7 +217,7 @@ impl WireFormat for ServiceEntry {
         16
     }
 
-    fn encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn encode<W: embedded_io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         writer.write_u8(self.index_first_options_run)?;
         writer.write_u8(self.index_second_options_run)?;
         writer.write_u8(u8::from(self.options_count))?;
@@ -277,7 +277,7 @@ impl Entry {
 }
 
 impl WireFormat for Entry {
-    fn decode<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
+    fn decode<R: embedded_io::Read>(reader: &mut R) -> Result<Self, Error> {
         let entry_type = EntryType::try_from(reader.read_u8()?)?;
         match entry_type {
             EntryType::FindService => {
@@ -315,7 +315,7 @@ impl WireFormat for Entry {
         }
     }
 
-    fn encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn encode<W: embedded_io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         match self {
             Entry::FindService(service_entry) => {
                 writer.write_u8(u8::from(EntryType::FindService))?;

--- a/src/protocol/sd/header.rs
+++ b/src/protocol/sd/header.rs
@@ -128,7 +128,7 @@ impl Header {
 }
 
 impl WireFormat for Header {
-    fn decode<T: std::io::Read>(reader: &mut T) -> Result<Self, crate::protocol::Error> {
+    fn decode<T: embedded_io::Read>(reader: &mut T) -> Result<Self, crate::protocol::Error> {
         let flags = Flags::from(reader.read_u8()?);
         let mut reserved: [u8; 3] = [0; 3];
         reader.read_bytes(&mut reserved)?;
@@ -164,7 +164,7 @@ impl WireFormat for Header {
         size
     }
 
-    fn encode<T: std::io::Write>(
+    fn encode<T: embedded_io::Write>(
         &self,
         writer: &mut T,
     ) -> Result<usize, crate::protocol::Error> {

--- a/src/protocol/sd/options.rs
+++ b/src/protocol/sd/options.rs
@@ -105,7 +105,7 @@ impl Options {
         }
     }
 
-    pub fn write<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, Error> {
+    pub fn write<T: embedded_io::Write>(&self, writer: &mut T) -> Result<usize, Error> {
         writer.write_u16_be(u16::try_from(self.size() - 3).expect("option size fits u16"))?;
         match self {
             Options::Configuration => todo!("Options::Configuration not implemented"),
@@ -127,7 +127,7 @@ impl Options {
         }
     }
 
-    pub fn read<T: std::io::Read>(message_bytes: &mut T) -> Result<Self, Error> {
+    pub fn read<T: embedded_io::Read>(message_bytes: &mut T) -> Result<Self, Error> {
         let length = message_bytes.read_u16_be()?;
         let option_type = OptionType::try_from(message_bytes.read_u8()?)?;
         let discard_flag = message_bytes.read_u8()? & 0x80 != 0;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -343,7 +343,6 @@ impl Server {
     pub async fn run(&mut self) -> Result<(), Error> {
         use crate::protocol::Header as SomeIpHeader;
         use crate::traits::WireFormat;
-        use std::io::Cursor;
 
         let mut unicast_buf = vec![0u8; 65535];
         let mut sd_buf = vec![0u8; 65535];
@@ -373,8 +372,8 @@ impl Server {
             tracing::trace!("Raw data: {:02X?}", &data[..len.min(64)]);
 
             // Try to parse as SOME/IP message
-            let mut cursor = Cursor::new(data);
-            match SomeIpHeader::decode(&mut cursor) {
+            let mut reader = data;
+            match SomeIpHeader::decode(&mut reader) {
                 Ok(header) => {
                     tracing::trace!("SOME/IP Header: service=0x{:04X}, method=0x{:04X}, type={:?}",
                         header.message_id.service_id(),
@@ -387,7 +386,7 @@ impl Server {
                        header.message_id.method_id() == 0x8100 {
                         tracing::trace!("This is an SD message");
                         // Parse SD payload
-                        match sd::Header::decode(&mut cursor) {
+                        match sd::Header::decode(&mut reader) {
                             Ok(sd_msg) => {
                                 tracing::trace!("SD message has {} entries, {} options",
                                     sd_msg.entries.len(),
@@ -677,9 +676,9 @@ mod tests {
 
     /// Helper: parse a SubscribeAck/Nack from raw response bytes, returns the TTL
     fn parse_subscribe_ack_ttl(data: &[u8]) -> u32 {
-        let mut cursor = std::io::Cursor::new(data);
-        let _header = SomeIpHeader::decode(&mut cursor).expect("Failed to parse SOME/IP header");
-        let sd_msg = sd::Header::decode(&mut cursor).expect("Failed to parse SD header");
+        let mut reader = data;
+        let _header = SomeIpHeader::decode(&mut reader).expect("Failed to parse SOME/IP header");
+        let sd_msg = sd::Header::decode(&mut reader).expect("Failed to parse SD header");
         assert_eq!(sd_msg.entries.len(), 1, "Expected exactly 1 entry in response");
         match &sd_msg.entries[0] {
             sd::Entry::SubscribeAckEventGroup(entry) => entry.ttl,
@@ -740,10 +739,10 @@ mod tests {
             let mut buf = vec![0u8; 65535];
             let (len, addr) = server.unicast_socket.recv_from(&mut buf).await.unwrap();
             let data = &buf[..len];
-            let mut cursor = std::io::Cursor::new(data);
-            let header = SomeIpHeader::decode(&mut cursor).unwrap();
+            let mut reader: &[u8] = data;
+            let header = SomeIpHeader::decode(&mut reader).unwrap();
             assert_eq!(header.message_id.service_id(), 0xFFFF);
-            let sd_msg = sd::Header::decode(&mut cursor).unwrap();
+            let sd_msg = sd::Header::decode(&mut reader).unwrap();
             server.handle_sd_message(sd_msg, addr).await.unwrap();
 
             // Check subscription was added
@@ -795,9 +794,9 @@ mod tests {
         let server_handle = tokio::spawn(async move {
             let mut buf = vec![0u8; 65535];
             let (len, addr) = server.unicast_socket.recv_from(&mut buf).await.unwrap();
-            let mut cursor = std::io::Cursor::new(&buf[..len]);
-            let _header = SomeIpHeader::decode(&mut cursor).unwrap();
-            let sd_msg = sd::Header::decode(&mut cursor).unwrap();
+            let mut reader: &[u8] = &buf[..len];
+            let _header = SomeIpHeader::decode(&mut reader).unwrap();
+            let sd_msg = sd::Header::decode(&mut reader).unwrap();
             server.handle_sd_message(sd_msg, addr).await.unwrap();
 
             // No subscription should have been added
@@ -846,9 +845,9 @@ mod tests {
         let server_handle = tokio::spawn(async move {
             let mut buf = vec![0u8; 65535];
             let (len, addr) = server.unicast_socket.recv_from(&mut buf).await.unwrap();
-            let mut cursor = std::io::Cursor::new(&buf[..len]);
-            let _header = SomeIpHeader::decode(&mut cursor).unwrap();
-            let sd_msg = sd::Header::decode(&mut cursor).unwrap();
+            let mut reader: &[u8] = &buf[..len];
+            let _header = SomeIpHeader::decode(&mut reader).unwrap();
+            let sd_msg = sd::Header::decode(&mut reader).unwrap();
             server.handle_sd_message(sd_msg, addr).await.unwrap();
 
             let subs = server.subscriptions.read().await;
@@ -896,9 +895,9 @@ mod tests {
         let server_handle = tokio::spawn(async move {
             let mut buf = vec![0u8; 65535];
             let (len, addr) = server.unicast_socket.recv_from(&mut buf).await.unwrap();
-            let mut cursor = std::io::Cursor::new(&buf[..len]);
-            let _header = SomeIpHeader::decode(&mut cursor).unwrap();
-            let sd_msg = sd::Header::decode(&mut cursor).unwrap();
+            let mut reader: &[u8] = &buf[..len];
+            let _header = SomeIpHeader::decode(&mut reader).unwrap();
+            let sd_msg = sd::Header::decode(&mut reader).unwrap();
             server.handle_sd_message(sd_msg, addr).await.unwrap();
 
             // Subscription should have been added

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,7 @@
 use crate::protocol::{self, MessageId};
 
 /// A trait for types that can be deserialized from a
-/// [`Reader`](https://doc.rust-lang.org/std/io/trait.Read.html) and serialized
-/// to a [`Writer`](https://doc.rust-lang.org/std/io/trait.Write.html).
+/// [`Reader`](embedded_io::Read) and serialized to a [`Writer`](embedded_io::Write).
 ///
 /// `WireFormat` acts as the base trait for all types that can be serialized and deserialized
 /// as part of the Simple SOME/IP ecosystem.
@@ -13,7 +12,7 @@ pub trait WireFormat: Send + Sized + Sync {
     /// # Errors
     /// - if the stream is not in the expected format
     /// - if the stream contains partial data
-    fn decode<T: std::io::Read>(reader: &mut T) -> Result<Self, protocol::Error>;
+    fn decode<T: embedded_io::Read>(reader: &mut T) -> Result<Self, protocol::Error>;
 
     /// Returns the number of bytes required to serialize this value.
     fn required_size(&self) -> usize;
@@ -22,11 +21,11 @@ pub trait WireFormat: Send + Sized + Sync {
     /// Returns the number of bytes written.
     /// # Errors
     /// - If the data cannot be written to the stream
-    fn encode<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, protocol::Error>;
+    fn encode<T: embedded_io::Write>(&self, writer: &mut T) -> Result<usize, protocol::Error>;
 }
 
 /// A trait for SOME/IP Payload types that can be deserialized from a
-/// [`Reader`](std::io::Read) and serialized to a [`Writer`](std::io::Write).
+/// [`Reader`](embedded_io::Read) and serialized to a [`Writer`](embedded_io::Write).
 /// Note that SOME/IP payloads are not self identifying, so the [Message ID](protocol::MessageId)
 /// must be provided by the caller after reading from the [SOME/IP header](protocol::Header).
 pub trait PayloadWireFormat: std::fmt::Debug + Send + Sized + Sync {
@@ -34,8 +33,8 @@ pub trait PayloadWireFormat: std::fmt::Debug + Send + Sized + Sync {
     fn message_id(&self) -> MessageId;
     /// Get the payload as a service discovery header
     fn as_sd_header(&self) -> Option<&crate::protocol::sd::Header>;
-    /// Deserialize a payload from a [Reader](std::io::Read) given the Message ID.
-    fn decode_with_message_id<T: std::io::Read>(
+    /// Deserialize a payload from a [Reader](embedded_io::Read) given the Message ID.
+    fn decode_with_message_id<T: embedded_io::Read>(
         message_id: MessageId,
         reader: &mut T,
     ) -> Result<Self, protocol::Error>;
@@ -43,8 +42,8 @@ pub trait PayloadWireFormat: std::fmt::Debug + Send + Sized + Sync {
     fn new_sd_payload(header: &crate::protocol::sd::Header) -> Self;
     /// Number of bytes required to write the payload
     fn required_size(&self) -> usize;
-    /// Serialize the payload to a [Writer](std::io::Write)
-    fn encode<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, protocol::Error>;
+    /// Serialize the payload to a [Writer](embedded_io::Write)
+    fn encode<T: embedded_io::Write>(&self, writer: &mut T) -> Result<usize, protocol::Error>;
 }
 
 /// A simple implementation of [`PayloadWireFormat`] that only supports SOME/IP-SD messages.
@@ -62,7 +61,7 @@ impl PayloadWireFormat for DiscoveryOnlyPayload {
         Some(&self.header)
     }
 
-    fn decode_with_message_id<T: std::io::Read>(
+    fn decode_with_message_id<T: embedded_io::Read>(
         message_id: MessageId,
         reader: &mut T,
     ) -> Result<Self, protocol::Error> {
@@ -85,7 +84,7 @@ impl PayloadWireFormat for DiscoveryOnlyPayload {
         self.header.required_size()
     }
 
-    fn encode<T: std::io::Write>(&self, writer: &mut T) -> Result<usize, protocol::Error> {
+    fn encode<T: embedded_io::Write>(&self, writer: &mut T) -> Result<usize, protocol::Error> {
         self.header.encode(writer)
     }
 }


### PR DESCRIPTION
embedded io allows for the wire_format trait to exist without requiring the dependency on std::io