### PR TITLE
Add loopback support for simple someip.

### DIFF
--- a/src/client/inner.rs
+++ b/src/client/inner.rs
@@ -887,6 +887,7 @@ mod tests {
         let (control_sender, mut update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
         // Drop control sender to trigger loop exit
         drop(control_sender);
@@ -920,6 +921,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let (rx, msg) = TestControl::bind_discovery();
@@ -935,6 +937,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let (rx, msg) = TestControl::unbind_discovery();
@@ -950,6 +953,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // SetInterface(LOCALHOST) on a fresh inner goes straight to
@@ -967,6 +971,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Bind discovery first so the SendSD path has a socket to use
@@ -995,6 +1000,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Bind discovery so SetInterface will take the multi-step path:
@@ -1064,6 +1070,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
@@ -1080,6 +1087,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let (rx, msg) = TestControl::remove_endpoint(0x1234, 0x0001);
@@ -1095,6 +1103,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Add an endpoint first so SendToService doesn't fail with ServiceNotFound
@@ -1119,6 +1128,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let (rx, msg) = TestControl::bind_discovery();
@@ -1137,6 +1147,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let target = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 30490);
@@ -1156,6 +1167,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
@@ -1179,6 +1191,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Bind discovery first
@@ -1208,6 +1221,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Add endpoint but do NOT bind discovery
@@ -1231,6 +1245,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let (rx, msg) = TestControl::subscribe(0xFFFF, 0xFFFF, 1, 3, 0x01, 0);
@@ -1248,6 +1263,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
@@ -1281,6 +1297,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         let (rx, msg) = TestControl::subscribe(0x1234, 0x0001, 1, 3, 0x01, 0);
@@ -1297,6 +1314,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Change to a different loopback-range address (127.0.0.2).
@@ -1320,6 +1338,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Bind discovery on LOCALHOST first
@@ -1349,6 +1368,7 @@ mod tests {
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
             Ipv4Addr::LOCALHOST,
             Arc::new(Mutex::new(E2ERegistry::new())),
+            false,
         );
 
         // Add endpoint and bind discovery

--- a/src/client/inner.rs
+++ b/src/client/inner.rs
@@ -1123,6 +1123,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bind_discovery_with_loopback() {
+        // Spawn inner with multicast_loopback=true so bind_discovery exercises
+        // the loopback-enabled branch of SocketManager::bind_discovery.
+        let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(
+            Ipv4Addr::LOCALHOST,
+            Arc::new(Mutex::new(E2ERegistry::new())),
+            true,
+        );
+
+        let (rx, msg) = TestControl::bind_discovery();
+        control_sender.send(msg).await.unwrap();
+        rx.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
     async fn test_bind_discovery_idempotent() {
         // Binding discovery twice should succeed (early return on already-bound)
         let (control_sender, _update_receiver) = Inner::<TestPayload>::spawn(

--- a/src/client/inner.rs
+++ b/src/client/inner.rs
@@ -235,6 +235,8 @@ pub(super) struct Inner<PayloadDefinitions: PayloadWireFormat> {
     session_counter: u16,
     /// Shared E2E registry for runtime E2E configuration
     e2e_registry: Arc<Mutex<E2ERegistry>>,
+    /// Enable multicast loopback on SD sockets for same-host testing
+    multicast_loopback: bool,
     /// Phantom data to represent the generic message definitions
     phantom: std::marker::PhantomData<PayloadDefinitions>,
 }
@@ -258,6 +260,7 @@ where
     pub fn spawn(
         interface: Ipv4Addr,
         e2e_registry: Arc<Mutex<E2ERegistry>>,
+        multicast_loopback: bool,
     ) -> (
         Sender<ControlMessage<PayloadDefinitions>>,
         mpsc::UnboundedReceiver<ClientUpdate<PayloadDefinitions>>,
@@ -279,6 +282,7 @@ where
             client_id: 0x1234,
             session_counter: 1,
             e2e_registry,
+            multicast_loopback,
             phantom: std::marker::PhantomData,
         };
         inner.run();
@@ -289,8 +293,11 @@ where
         if self.discovery_socket.is_some() {
             Ok(())
         } else {
-            let socket =
-                SocketManager::bind_discovery(self.interface, Arc::clone(&self.e2e_registry))?;
+            let socket = SocketManager::bind_discovery(
+                self.interface,
+                Arc::clone(&self.e2e_registry),
+                self.multicast_loopback,
+            )?;
             self.discovery_socket = Some(socket);
             Ok(())
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -169,6 +169,23 @@ where
     /// are looped back to other sockets on the same host. This is required
     /// when running both a client and a server/simulator on the same machine
     /// for testing. Defaults to `false` in [`Self::new`].
+    ///
+    /// # Loopback caveat
+    ///
+    /// With loopback enabled, the client's own discovery socket also receives
+    /// the multicast SD traffic this client sends (e.g. `FindService` probes
+    /// and periodic `OfferService` announcements driven by
+    /// [`Self::start_sd_announcements`]). Those self-sent messages are parsed
+    /// the same as any other inbound SD traffic, so callers may observe:
+    ///
+    /// - [`ClientUpdate::DiscoveryUpdated`] events originating from this
+    ///   client's own IP/port, and
+    /// - self-advertised services appearing in the internal discovery
+    ///   registry.
+    ///
+    /// Consumers of [`ClientUpdates`] that need to ignore self-sent SD should
+    /// filter on source address (the sender's IP/port is included on the
+    /// update).
     #[must_use]
     pub fn new_with_loopback(
         interface: Ipv4Addr,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -160,8 +160,23 @@ where
     /// discovery, unicast, and error updates from the event loop.
     #[must_use]
     pub fn new(interface: Ipv4Addr) -> (Self, ClientUpdates<MessageDefinitions>) {
+        Self::new_with_loopback(interface, false)
+    }
+
+    /// Like [`Self::new`], but with explicit control over multicast loopback.
+    ///
+    /// When `multicast_loopback` is `true`, SD messages sent by this client
+    /// are looped back to other sockets on the same host. This is required
+    /// when running both a client and a server/simulator on the same machine
+    /// for testing. Defaults to `false` in [`Self::new`].
+    #[must_use]
+    pub fn new_with_loopback(
+        interface: Ipv4Addr,
+        multicast_loopback: bool,
+    ) -> (Self, ClientUpdates<MessageDefinitions>) {
         let e2e_registry = Arc::new(Mutex::new(E2ERegistry::new()));
-        let (control_sender, update_receiver) = Inner::spawn(interface, Arc::clone(&e2e_registry));
+        let (control_sender, update_receiver) =
+            Inner::spawn(interface, Arc::clone(&e2e_registry), multicast_loopback);
 
         let client = Self {
             interface: Arc::new(RwLock::new(interface)),

--- a/src/client/socket_manager.rs
+++ b/src/client/socket_manager.rs
@@ -80,10 +80,13 @@ where
         socket.set_reuse_port(true)?;
         socket.set_multicast_if_v4(&interface)?;
         // Control whether multicast packets sent by this socket are looped
-        // back to other sockets on the same host. Disabled by default to
-        // avoid parsing self-sent OfferService entries as peer offers.
-        // Enable for same-host testing (e.g. simulator + client on one
-        // machine).
+        // back to sockets on the same host — INCLUDING this socket itself.
+        // Disabled by default to avoid parsing self-sent OfferService /
+        // FindService entries as if they came from a peer. When enabled
+        // (e.g. for a same-host simulator + client setup), the kernel will
+        // deliver this socket's own SD multicasts back to it, so higher-level
+        // consumers must be prepared to see their own announcements surface
+        // as inbound discovery traffic.
         socket.set_multicast_loop_v4(multicast_loopback)?;
         socket.bind(&bind_addr.into())?;
         socket.set_nonblocking(true)?;

--- a/src/client/socket_manager.rs
+++ b/src/client/socket_manager.rs
@@ -62,6 +62,7 @@ where
     pub fn bind_discovery(
         interface: Ipv4Addr,
         e2e_registry: Arc<Mutex<E2ERegistry>>,
+        multicast_loopback: bool,
     ) -> Result<Self, Error> {
         let (rx_tx, rx_rx) = mpsc::channel(16);
         let (tx_tx, tx_rx) = mpsc::channel(16);
@@ -78,12 +79,12 @@ where
         #[cfg(unix)]
         socket.set_reuse_port(true)?;
         socket.set_multicast_if_v4(&interface)?;
-        // Disable multicast loopback so this socket does not receive the
-        // SD messages it sends. Matches the Server's SD socket setup —
-        // otherwise a client that acts as both server and client (e.g.
-        // offering services via `start_sd_announcements`) will parse its
-        // own OfferService entries as peer offers.
-        socket.set_multicast_loop_v4(false)?;
+        // Control whether multicast packets sent by this socket are looped
+        // back to other sockets on the same host. Disabled by default to
+        // avoid parsing self-sent OfferService entries as peer offers.
+        // Enable for same-host testing (e.g. simulator + client on one
+        // machine).
+        socket.set_multicast_loop_v4(multicast_loopback)?;
         socket.bind(&bind_addr.into())?;
         socket.set_nonblocking(true)?;
         let socket: std::net::UdpSocket = socket.into();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -45,8 +45,6 @@ pub struct ServerConfig {
     pub minor_version: u32,
     /// Service Discovery TTL (time to live)
     pub ttl: u32,
-    /// Enable multicast loopback on the SD socket for same-host testing.
-    pub multicast_loopback: bool,
 }
 
 impl ServerConfig {
@@ -61,7 +59,6 @@ impl ServerConfig {
             major_version: 1,
             minor_version: 0,
             ttl: 3, // 3 seconds is typical for SOME/IP
-            multicast_loopback: false,
         }
     }
 }
@@ -97,6 +94,24 @@ impl Server {
     /// Returns an error if binding the unicast or SD socket fails, or if joining the
     /// SD multicast group fails.
     pub async fn new(config: ServerConfig) -> Result<Self, Error> {
+        Self::new_with_loopback(config, false).await
+    }
+
+    /// Like [`Self::new`], but with explicit control over multicast loopback.
+    ///
+    /// When `multicast_loopback` is `true`, SD messages sent by this server
+    /// are looped back to other sockets on the same host. This is required
+    /// when running both a server and a client/simulator on the same machine
+    /// for testing. Defaults to `false` in [`Self::new`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if binding the unicast or SD socket fails, or if joining the
+    /// SD multicast group fails.
+    pub async fn new_with_loopback(
+        config: ServerConfig,
+        multicast_loopback: bool,
+    ) -> Result<Self, Error> {
         // Bind unicast socket for receiving subscriptions
         let unicast_addr = SocketAddrV4::new(config.interface, config.local_port);
         let unicast_socket = Arc::new(UdpSocket::bind(unicast_addr).await?);
@@ -119,7 +134,7 @@ impl Server {
         #[cfg(unix)]
         sd_raw_socket.set_reuse_port(true)?;
         sd_raw_socket.set_multicast_if_v4(&config.interface)?;
-        sd_raw_socket.set_multicast_loop_v4(config.multicast_loopback)?;
+        sd_raw_socket.set_multicast_loop_v4(multicast_loopback)?;
         sd_raw_socket.bind(&sd_bind_addr.into())?;
         sd_raw_socket.set_nonblocking(true)?;
         let sd_std_socket: std::net::UdpSocket = sd_raw_socket.into();
@@ -522,8 +537,12 @@ impl Server {
             };
             let data = &data[..len];
 
-            // Own multicast messages are suppressed via IP_MULTICAST_LOOP=false
-            // on the SD socket, so no source-IP filtering is needed here.
+            // By default IP_MULTICAST_LOOP=false suppresses own multicast
+            // messages on the SD socket, so no source-IP filtering is needed.
+            // When the server was constructed via `Server::new_with_loopback`
+            // with `multicast_loopback = true` (e.g. for same-host testing),
+            // the kernel will deliver our own SD multicasts back to us here;
+            // callers are expected to tolerate or filter those.
 
             tracing::trace!("Received {} bytes from {} on {} socket", len, addr, source);
             tracing::trace!("Raw data: {:02X?}", &data[..len.min(64_usize)]);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -100,9 +100,22 @@ impl Server {
     /// Like [`Self::new`], but with explicit control over multicast loopback.
     ///
     /// When `multicast_loopback` is `true`, SD messages sent by this server
-    /// are looped back to other sockets on the same host. This is required
-    /// when running both a server and a client/simulator on the same machine
-    /// for testing. Defaults to `false` in [`Self::new`].
+    /// are looped back to sockets on the same host — including this server's
+    /// own SD socket. This is required when running both a server and a
+    /// client/simulator on the same machine for testing. Defaults to `false`
+    /// in [`Self::new`].
+    ///
+    /// # Loopback caveat
+    ///
+    /// With loopback enabled, this server's SD receive loop (see
+    /// [`Self::run`]) will observe the `OfferService` announcements it just
+    /// sent. [`Self::run`] already ignores SD entry types that are
+    /// not `Subscribe` / `SubscribeAck` / `FindService`, so self-sent
+    /// offers are harmless. If this server has ever offered its own
+    /// service ID, any self-sent `FindService` for that same service would
+    /// also be answered with a unicast `OfferService` reply back to itself;
+    /// this is expected and symmetric with how an external peer's
+    /// `FindService` would be handled.
     ///
     /// # Errors
     ///
@@ -541,8 +554,14 @@ impl Server {
             // messages on the SD socket, so no source-IP filtering is needed.
             // When the server was constructed via `Server::new_with_loopback`
             // with `multicast_loopback = true` (e.g. for same-host testing),
-            // the kernel will deliver our own SD multicasts back to us here;
-            // callers are expected to tolerate or filter those.
+            // the kernel delivers our own SD multicasts back to this loop.
+            // That is tolerated here: `handle_sd_message` only acts on
+            // `Subscribe` / `SubscribeAck` / `FindService` entries, so the
+            // `OfferService` entries we send ourselves are effectively
+            // ignored. A self-sent `FindService` for our own service ID
+            // would trigger a unicast `OfferService` reply back to
+            // ourselves, which is the same behavior an external peer's
+            // `FindService` would produce and is therefore safe.
 
             tracing::trace!("Received {} bytes from {} on {} socket", len, addr, source);
             tracing::trace!("Raw data: {:02X?}", &data[..len.min(64_usize)]);
@@ -887,6 +906,30 @@ mod tests {
 
         let server: Result<Server, _> = Server::new(config).await;
         assert!(server.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_server_creation_with_loopback_enabled() {
+        // Use a unicast port distinct from other tests to avoid EADDRINUSE
+        // when the test binary runs tests in parallel. The SD socket binds
+        // the SD multicast port (30490) and relies on SO_REUSEPORT, the same
+        // as `test_server_creation`.
+        let config = ServerConfig::new(Ipv4Addr::new(127, 0, 0, 1), 30683, 0x5C, 1);
+
+        let server = Server::new_with_loopback(config, true)
+            .await
+            .expect("new_with_loopback(true) should succeed on localhost");
+
+        // Confirm the SD socket was actually configured with IP_MULTICAST_LOOP
+        // enabled — this is the behavior the new code path is supposed to
+        // produce and is what makes same-host testing possible.
+        let sock_ref = socket2::SockRef::from(&*server.sd_socket);
+        assert!(
+            sock_ref
+                .multicast_loop_v4()
+                .expect("multicast_loop_v4 getter should succeed"),
+            "multicast loopback should be enabled on the SD socket",
+        );
     }
 
     /// Helper: wrap an SD header in a SOME/IP SD message and return the bytes

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -45,6 +45,8 @@ pub struct ServerConfig {
     pub minor_version: u32,
     /// Service Discovery TTL (time to live)
     pub ttl: u32,
+    /// Enable multicast loopback on the SD socket for same-host testing.
+    pub multicast_loopback: bool,
 }
 
 impl ServerConfig {
@@ -59,6 +61,7 @@ impl ServerConfig {
             major_version: 1,
             minor_version: 0,
             ttl: 3, // 3 seconds is typical for SOME/IP
+            multicast_loopback: false,
         }
     }
 }
@@ -116,7 +119,7 @@ impl Server {
         #[cfg(unix)]
         sd_raw_socket.set_reuse_port(true)?;
         sd_raw_socket.set_multicast_if_v4(&config.interface)?;
-        sd_raw_socket.set_multicast_loop_v4(false)?;
+        sd_raw_socket.set_multicast_loop_v4(config.multicast_loopback)?;
         sd_raw_socket.bind(&sd_bind_addr.into())?;
         sd_raw_socket.set_nonblocking(true)?;
         let sd_std_socket: std::net::UdpSocket = sd_raw_socket.into();


### PR DESCRIPTION
Added loopback support within the iris someip client/server itself to enable locally-run tests